### PR TITLE
Support for AWS S3 cache

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -288,3 +288,53 @@ Example
         default_ports:
             pb: 8087
             http: 8098
+
+``s3``
+===========
+
+.. versionadded:: 1.x.x
+
+Store tiles in a `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_.
+
+
+Requirements
+------------
+
+
+You will need the Python `boto <https://github.com/boto/boto>`_  version 2.34.0 or newer. You can install it in the usual way, for example with ``pip install boto``. 
+
+
+Configuration
+-------------
+
+
+Available options:
+
+``bucketname``:
+  The bucket MapProxy uses for this cache. The bucket is unique for all layers using this type of cache.
+
+``profilename``:
+  Optional boto `credentials <http://boto.cloudhackers.com/en/latest/boto_config_tut.html>`_ for this cache. Alternative methods of authentification are using the  ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environmental variables, or by using an `IAM role <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_ when using an Amazon EC2 instance.
+
+
+Example
+-------
+
+::
+
+    
+    cache:
+        my_layer_20110501_epsg_4326_cache_out:
+            cache:
+                cache_dir: /1.0.0/my_layer/default/20110501/4326/
+                directory_layout: tms
+                type: s3
+            disable_storage: false
+            format: image/png
+        sources:
+            - my_layer_20110501_cache
+
+    globals:
+        cache:
+            bucket_name: my-s3-tiles-cache
+

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -1,0 +1,182 @@
+from __future__ import with_statement
+
+import os
+from mapproxy.image import ImageSource
+from mapproxy.cache.base import tile_buffer
+from mapproxy.cache.file import FileCache
+
+try:
+    import boto
+except ImportError:
+    boto = None
+
+import StringIO
+
+import logging
+log = logging.getLogger('mapproxy.cache.s3')
+
+s3_connection = None
+
+class S3Connection:
+    def __init__(self, profile_name='mapproxy'):
+        if boto is None:
+            raise ImportError("S3 Cache requires 'boto' package.")
+        self.conn = None
+        self.profile_name = profile_name
+
+    def get(self):
+        if self.conn is None:
+            try:
+                self.conn = boto.connect_s3(profile_name=self.profile_name)
+            except Exception as e:
+                raise Error('S3: Error during connection %s' % e)
+        return self.conn
+
+
+
+def get_bucket(profile_name, bucket_name):
+        global s3_connection
+        if s3_connection is None:
+            s3_connection = S3Connection(profile_name=profile_name)
+        try:
+            conn = s3_connection.get()
+            bucket = conn.get_bucket(bucket_name)
+        except boto.exception.S3ResponseError as e:
+            if e.error_code == 'NoSuchBucket':
+                log.error('No such bucket: %s' % bucket_name)
+                raise e
+        return bucket
+               
+
+class S3Cache(FileCache):
+
+    """
+    This class is responsible to store and load the actual tile data.
+    """
+
+    def __init__(self, cache_dir, file_ext, lock_dir=None, directory_layout='tms',
+                 lock_timeout=60.0, bucket_name='mapproxy', profile_name=None):
+        """
+        :param cache_dir: the path where the tile will be stored
+        :param file_ext: the file extension that will be appended to
+            each tile (e.g. 'png')
+        """
+        global s3_connection
+        
+        if s3_connection is None:
+            s3_connection = S3Connection(profile_name=profile_name)
+        try:
+            conn = s3_connection.get()
+            self.bucket = conn.get_bucket(bucket_name)
+        except boto.exception.S3ResponseError as e:
+            if e.error_code == 'NoSuchBucket':
+                log.error('No such bucket: %s' % bucket_name)
+                raise e
+
+
+  
+        super(S3Cache, self).__init__(cache_dir, file_ext=file_ext, directory_layout=directory_layout, lock_timeout=lock_timeout, link_single_color_images=False)
+
+
+    def load_tile_metadata(self, tile):
+        # TODO Implement storing / retrieving tile metadata
+        tile.timestamp = 0
+        tile.size = 0
+
+    def is_cached(self, tile):
+        """
+        Returns ``True`` if the tile data is present.
+        """
+        if tile.is_missing():
+
+            location = self.tile_location(tile)
+
+            k = boto.s3.key.Key(self.bucket)
+            k.key = location
+            if k.exists():
+                log.debug('S3: cache HIT, location: %s' % location)
+                return True
+            else:
+                log.debug('S3: cache MISS, location: %s' % location)
+                return False
+        else:
+            return True
+
+    def load_tile(self, tile, with_metadata=False):
+        """
+        Fills the `Tile.source` of the `tile` if it is cached.
+        If it is not cached or if the ``.coord`` is ``None``, nothing happens.
+        """
+        if not tile.is_missing():
+            return True
+
+        location = self.tile_location(tile)
+        log.debug('S3:load_tile, location: %s' % location)
+
+        tile_data = StringIO.StringIO()
+        k = boto.s3.key.Key(self.bucket)
+        k.key = location
+        try:
+            k.get_contents_to_file(tile_data)
+            tile.source = ImageSource(tile_data)
+            k.close()
+            return True
+        except boto.exception.S3ResponseError:
+            # NoSuchKey
+            pass
+        k.close()
+        return False
+
+    def remove_tile(self, tile):
+
+        location = self.tile_location(tile)
+        log.debug('remove_tile, location: %s' % location)
+
+        k = boto.s3.key.Key(self.bucket)
+        k.key = location
+        if k.exists():
+            k.delete()
+        k.close()
+
+    def store_tile(self, tile):
+        """
+        Add the given `tile` to the file cache. Stores the `Tile.source` to
+        `FileCache.tile_location`.
+        """
+        if tile.stored:
+            return
+
+        location = self.tile_location(tile)
+        log.debug('S3: store_tile, location: %s' % location)
+
+        k = boto.s3.key.Key(self.bucket)
+        if self.file_ext in ('jpeg', 'png'):
+            k.content_type = 'image/' + self.file_ext
+        k.key = location
+        with tile_buffer(tile) as buf:
+            k.set_contents_from_file(buf)
+        k.close()
+
+        # Attempt making storing tiles non-blocking
+
+        # This is still blocking when I thought that it would not
+        # async.run_non_blocking(self.async_store, (k, tile))
+
+        # async_pool = async.Pool(4)
+        # for store in async_pool.map(self.async_store_, [(k, tile)]):
+        #     log.debug('stored...')
+
+        # This sometimes suffers from "ValueError: I/O operation on closed file"
+        # as I guess it's not advised to use threads within a wsgi app
+        # Timer(0.25, self.async_store, args=[k, tile]).start()
+
+    def async_store_(self, foo):
+        key, tile = foo
+        print 'Storing %s, %s' % (key, tile)
+        with tile_buffer(tile) as buf:
+            key.set_contents_from_file(buf)
+
+    def async_store(self, key, tile):
+        print 'Storing %s, %s' % (key, tile)
+        with tile_buffer(tile) as buf:
+            key.set_contents_from_file(buf)

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -969,6 +969,40 @@ class CacheConfiguration(ConfigurationBase):
             mbfile_path,
         )
 
+    def _s3_cache(self, grid_conf, file_ext):
+        from mapproxy.cache.s3 import S3Cache
+        
+        cache_dir = self.conf.get('cache', {}).get('cache_dir', None)
+        #bucket = self.conf.get('cache', {}).get('bucket', 'mapproxy')
+
+        #bucket = self.context.globals.get_value('bucket', self.conf, global_key='cache.bucket')
+
+        bucket_name = self.context.globals.get_value('bucket_name', self.conf,
+            global_key='cache.bucket_name')
+
+        profile_name = self.context.globals.get_value('profile_name', self.conf,
+            global_key='cache.s3_profile_name')
+
+
+        directory_layout = self.conf.get('cache', {}).get('directory_layout', 'tc')
+        g=grid_conf.tile_grid()
+        log.debug("S3 loader: name=%s, srs=%s" %  (g.name, g.srs))
+
+        if cache_dir is None:
+            if self.conf.get('cache', {}).get('use_grid_names'):
+                cache_dir = os.path.join(cache_dir, self.conf['name'], grid_conf.tile_grid().name)
+            else:
+                suffix = grid_conf.conf['srs'].replace(':', '')
+            
+            cache_dir = os.path.join(cache_dir, self.conf['name'] + '_' + suffix)
+
+        #cache_dir ='/1.0.0/osm/default/current/3857/'
+        
+        lock_timeout = self.context.globals.get_value('http.client_timeout', {})
+        
+        return S3Cache(cache_dir, file_ext=file_ext, directory_layout=directory_layout,
+            lock_timeout=lock_timeout, bucket_name=bucket_name, profile_name=profile_name)
+
     def _sqlite_cache(self, grid_conf, file_ext):
         from mapproxy.cache.mbtiles import MBTilesLevelCache
 
@@ -1421,8 +1455,12 @@ class LayerConfiguration(ConfigurationBase):
         for cache_name in sources:
             for grid, extent, cache_source in self.context.caches[cache_name].caches():
 
-                if dimensions and not isinstance(cache_source.cache, DummyCache):
+
+                from mapproxy.cache.s3 import S3Cache
+
+                if dimensions and not isinstance(cache_source.cache, DummyCache) and not isinstance(cache_source.cache, S3Cache):
                     # caching of dimension layers is not supported yet
+                    log.debug(type(cache_source.cache).__name__)
                     raise ConfigurationError(
                         "caching of dimension layer (%s) is not supported yet."
                         " need to `disable_storage: true` on %s cache" % (self.conf['name'], cache_name)

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -971,11 +971,8 @@ class CacheConfiguration(ConfigurationBase):
 
     def _s3_cache(self, grid_conf, file_ext):
         from mapproxy.cache.s3 import S3Cache
-        
-        cache_dir = self.conf.get('cache', {}).get('cache_dir', None)
-        #bucket = self.conf.get('cache', {}).get('bucket', 'mapproxy')
 
-        #bucket = self.context.globals.get_value('bucket', self.conf, global_key='cache.bucket')
+        cache_dir = self.conf.get('cache', {}).get('cache_dir', None)
 
         bucket_name = self.context.globals.get_value('bucket_name', self.conf,
             global_key='cache.bucket_name')
@@ -983,23 +980,18 @@ class CacheConfiguration(ConfigurationBase):
         profile_name = self.context.globals.get_value('profile_name', self.conf,
             global_key='cache.s3_profile_name')
 
-
-        directory_layout = self.conf.get('cache', {}).get('directory_layout', 'tc')
-        g=grid_conf.tile_grid()
-        log.debug("S3 loader: name=%s, srs=%s" %  (g.name, g.srs))
+        directory_layout = self.conf.get('cache', {}).get('directory_layout', 'tms')
 
         if cache_dir is None:
             if self.conf.get('cache', {}).get('use_grid_names'):
                 cache_dir = os.path.join(cache_dir, self.conf['name'], grid_conf.tile_grid().name)
             else:
                 suffix = grid_conf.conf['srs'].replace(':', '')
-            
+
             cache_dir = os.path.join(cache_dir, self.conf['name'] + '_' + suffix)
 
-        #cache_dir ='/1.0.0/osm/default/current/3857/'
-        
         lock_timeout = self.context.globals.get_value('http.client_timeout', {})
-        
+
         return S3Cache(cache_dir, file_ext=file_ext, directory_layout=directory_layout,
             lock_timeout=lock_timeout, bucket_name=bucket_name, profile_name=profile_name)
 

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -121,6 +121,13 @@ cache_types = {
         'tile_id': str(),
         'tile_lock_dir': str(),
     },
+    's3': {
+                'bucket_name': str(),
+                'directory_layout': str(),
+                'use_grid_names': bool(),
+                'cache_dir': str(),
+                'profile_name': str(),
+         },
     'riak': {
         'nodes': [riak_node],
         'protocol': one_of('pbc', 'http', 'https'),
@@ -314,6 +321,8 @@ mapproxy_yaml_spec = {
             'minimize_meta_requests': bool(),
             'concurrent_tile_creators': int(),
             'link_single_color_images': bool(),
+            'bucket_name': str(),
+            's3_profile_name': str(),
         },
         'grid': {
             'tile_size': [int()],

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -1,0 +1,43 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2011 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import with_statement
+
+import os
+import random
+
+from nose.plugins.skip import SkipTest
+
+from mapproxy.cache.s3 import S3Cache
+from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
+
+
+class TestS3Cache(TileCacheTestBase):
+    always_loads_metadata = True
+
+    def setup(self):
+        if not os.environ.get('MAPPROXY_TEST_S3'):
+            raise SkipTest()
+
+        bucket_name = os.environ['MAPPROXY_TEST_S3']
+        dir_name = 'mapproxy/test_%d' % random.randint(0, 100000)
+
+        TileCacheTestBase.setup(self)
+
+        self.cache = S3Cache(dir_name, file_ext='png', directory_layout='tms',
+                             lock_timeout=10, bucket_name=bucket_name, profile_name=None)
+
+    def teardown(self):
+        TileCacheTestBase.teardown(self)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ def package_installed(pkg):
     else:
         return True
 
+# Depend on boto 2.34
+install_requires.append('boto>=2.34')
+
 # depend in Pillow if it is installed, otherwise
 # depend on PIL if it is installed, otherwise
 # require Pillow


### PR DESCRIPTION
Adding a cache of type S3 to Mapproxy

Sample configuration:

```
caches:
  my_cache_out:
    cache:
      [...]
      type: s3
      directory_layout: tms
      cache_dir: /1.0.0/ch.swisstopo.pixelkarte-farbe/default/20151231/3857/

globals:
  cache:
    bucket_name: wmts.procrastinatio.org
    s3_profile_name: geodata

```

Mostly the work of [walkermatt](https://github.com/walkermatt/mapproxy/tree/s3)
